### PR TITLE
Resolve entry for package "@astro-auth/ui"

### DIFF
--- a/packages/astro-auth-ui/package.json
+++ b/packages/astro-auth-ui/package.json
@@ -26,6 +26,6 @@
     "src"
   ],
   "exports": {
-    ".": "./index.ts"
+    ".": "./src/index.ts"
   }
 }


### PR DESCRIPTION
 ### Changes
 - Fix incorrect export path
 
 ### Code
 Filepath: `src/components/Login.jsx` copy from [docs](https://astro-auth.weoffersolution.com/getting-started/using-astro-auth)
 ```jsx
import { GoogleButton } from "@astro-auth/ui";
import { signIn } from "@astro-auth/client";

const Login = () => {
    return (
        <div>
            <GoogleButton callbackURL="https://youtu.be/dQw4w9WgXcQ" />
            code
            <button
                onClick={() => {
                    signIn({
                        provider: "google",
                        callbackURL: "https://youtu.be/dQw4w9WgXcQ",
                    });
                }}
            >
                Login with Google
            </button>
        </div>
    );
};

export default Login;
 ```

### Error
```bash
✘ [ERROR] [plugin vite:dep-scan] Failed to resolve entry for package "@astro-auth/ui". The package may have incorrect main/module/exports specified in its package.json.

    node_modules/esbuild/lib/main.js:933:27:
      933 │               let result = await callback2({
          ╵                            ^

    at packageEntryFailure (file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:34705:11)
    at resolvePackageEntry (file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:34702:5)
    at tryNodeResolve (file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:34452:20)
    at Context.resolveId (file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:34254:28)
    at Object.resolveId (file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:35511:55)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async resolve (file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:36097:26)
    at async file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:36268:34
    at async callback (/workspace/astro-skidd/node_modules/esbuild/lib/main.js:933:28)
    at async handleRequest (/workspace/astro-skidd/node_modules/esbuild/lib/main.js:713:30)

  This error came from the "onResolve" callback registered here:

    node_modules/esbuild/lib/main.js:855:22:
      855 │         let promise = setup({
          ╵                       ^

    at setup (file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:36258:19)
    at handlePlugins (/workspace/astro-skidd/node_modules/esbuild/lib/main.js:855:23)
    at Object.buildOrServe (/workspace/astro-skidd/node_modules/esbuild/lib/main.js:1149:7)
    at /workspace/astro-skidd/node_modules/esbuild/lib/main.js:2110:17
    at new Promise (<anonymous>)
    at Object.build (/workspace/astro-skidd/node_modules/esbuild/lib/main.js:2109:14)
    at build (/workspace/astro-skidd/node_modules/esbuild/lib/main.js:1956:51)
    at file:///workspace/astro-skidd/node_modules/vite/dist/node/chunks/dep-0fc8e132.js:36045:46
    at Array.map (<anonymous>)

  The plugin "vite:dep-scan" was triggered by this import

    src/components/Login.jsx:1:29:
      1 │ import { GoogleButton } from "@astro-auth/ui";
        ╵                              ~~~~~~~~~~~~~~~~

Build failed with 1 error:
node_modules/esbuild/lib/main.js:933:27: ERROR: [plugin: vite:dep-scan] Failed to resolve entry for package "@astro-auth/ui". The package may have incorrect main/module/exports specified in its package.json.

```