### PR TITLE
Title doesn't match example

### DIFF
--- a/docs/src/pages/providers/oauth.md
+++ b/docs/src/pages/providers/oauth.md
@@ -21,7 +21,7 @@ Inside the `@astro-auth/provider` package, you will find 8 OAuth providers inclu
 7. SpotifyProvider
 8. ZoomProvider
 
-## Example For Using Discord OAuth
+## Example For Using Github OAuth
 
 src/pages/api/auth/[...astroauth.ts]
 


### PR DESCRIPTION
Title says it's a discord example, but is using GitHub provider